### PR TITLE
Generate types in 'dist/types'.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "keywords": [],
   "main": "dist/--libraryname--.js",
-  "typings": "dist/src/--libraryname--.d.ts",
+  "typings": "dist/types/--libraryname--.d.ts",
   "files": [
     "dist"
   ],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,11 +7,14 @@
         "strictNullChecks": true,
         "sourceMap": true,
         "declaration": true,
-        "outDir": "types",
+        "outDir": "dist/types",
         "typeRoots": [
           "node_modules/@types"
         ]
     },
+    "include": [
+        "src"
+    ]
     "awesomeTypescriptLoaderOptions": {
         "useBabel": true
     }


### PR DESCRIPTION
On Mac OSX, these changes allows type definitions to be generated in 'dist/types' rather than 'dist/src'.

*Note:* I have not tested this in other environments. I'd also like to note that when building on OSX initially, the types never generated to '/dist/src', but just '/types' in the first place. Thus I think this should be tested before pulling.