### PR TITLE
Generate types in "dist/types" (the right way?)

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@types/jest": "^18.1.1",
     "@types/node": "^7.0.2",
     "@types/webpack": "^2.2.7",
-    "awesome-typescript-loader": "^3.0.8",
+    "awesome-typescript-loader": "^3.1.0",
     "babel-core": "^6.22.1",
     "babel-preset-env": "^1.2.0",
     "colors": "^1.1.2",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,11 +7,14 @@
         "strictNullChecks": true,
         "sourceMap": true,
         "declaration": true,
-        "outDir": "types",
+        "declarationDir": "dist/types",
         "typeRoots": [
           "node_modules/@types"
         ]
     },
+    "include": [
+        "src"
+    ],
     "awesomeTypescriptLoaderOptions": {
         "useBabel": true
     }


### PR DESCRIPTION
I deleted the other fork without thinking. 

On OSX, the following configurations have their respective results:

 - Setting `declarationDir` to "types" results in types being generated in "types/src" (at the root of the project).
 - Setting `declarationDir` to "dist/types" results in types being generated in "dist/types/src".
 - Setting `declarationDir` to "dist/types" _and_ adding "src" as an `include` entry results in types being generated in "dist/types".

I assume the desired behavior is the last one (types in "dist/types" rather than "dist/types/src"). Thus, this PR reflects those changes. This still must be tested on other environments to make sure the results are consistent.

### Fix: 
- Upgrade awesome-typescript-loader to ^3.1.0
- Add “dist/types” as declarationDir entry in tsconfig.json
- Add “src” to include entry in tsconfig.json

### Fixed `tsconfig.json`:
```json
{
    "compilerOptions": {
        "moduleResolution": "node",
        "target": "es2015",
        "lib": ["es2016", "dom"],
        "noImplicitAny": true,
        "strictNullChecks": true,
        "sourceMap": true,
        "declaration": true,
        "declarationDir": "dist/types",
        "typeRoots": [
          "node_modules/@types"
        ]
    },
    "include": [
        "src"
    ],
    "awesomeTypescriptLoaderOptions": {
        "useBabel": true
    }
}
```