### PR TITLE
Fixed url parsing in gh-pages-publish.js

### DIFF
--- a/tools/gh-pages-publish.js
+++ b/tools/gh-pages-publish.js
@@ -2,9 +2,19 @@ let { cd, exec, echo, touch } = require('shelljs')
 let { readFileSync } = require('fs')
 let url = require('url')
 
+let repoUrl;
 let pkg = JSON.parse(readFileSync('package.json'))
-let repository = url.parse(pkg.repository)
-repository = repository.host + repository.path
+if (typeof pkg.repository === 'object') {
+    if (!pkg.repository.hasOwnProperty('url')) {
+        throw new Error("URL does not exist in repository section")
+    }
+    repoUrl = pkg.repository.url
+} else {
+    repoUrl = pkg.repository
+}
+
+var parsedUrl = url.parse(repoUrl)
+let repository = parsedUrl.host + parsedUrl.path;
 let ghToken = process.env.GH_TOKEN
 
 echo('Deploying docs!!!')

--- a/tools/gh-pages-publish.js
+++ b/tools/gh-pages-publish.js
@@ -13,7 +13,7 @@ if (typeof pkg.repository === 'object') {
     repoUrl = pkg.repository
 }
 
-var parsedUrl = url.parse(repoUrl)
+let parsedUrl = url.parse(repoUrl)
 let repository = parsedUrl.host + parsedUrl.path;
 let ghToken = process.env.GH_TOKEN
 


### PR DESCRIPTION
Due to issue #39 the changes have been made.

Added object validation for repository node - if repository is a complicated object - "url" property must exist. In other case (if it simple type) - the parsing process will use data stored in "repository" node.