### PR TITLE
Slim dependecies to just lodash.camelcase

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "husky": "^0.13.4",
     "jest": "^20.0.4",
     "lint-staged": "^4.0.0",
-    "lodash": "^4.17.4",
+    "lodash.camelcase": "^4.3.0",
     "prettier": "^1.4.4",
     "prompt": "^1.0.0",
     "replace-in-file": "^2.5.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,15 +2,15 @@ import resolve from 'rollup-plugin-node-resolve'
 import commonjs from 'rollup-plugin-commonjs'
 import sourceMaps from 'rollup-plugin-sourcemaps'
 const pkg = require('./package.json')
-const { camelCase } = require('lodash')
+const camelCase = require('lodash.camelcase')
 
 const libraryName = '--libraryname--'
 
 export default {
   entry: `compiled/${libraryName}.js`,
   targets: [
-		{ dest: pkg.main, moduleName: camelCase(libraryName), format: 'umd' },
-		{ dest: pkg.module, format: 'es' }
+	  { dest: pkg.main, moduleName: camelCase(libraryName), format: 'umd' },
+	  { dest: pkg.module, format: 'es' }
   ],
   sourceMap: true,
   // Indicate here external modules you don't wanna include in your bundle (i.e.: 'lodash')
@@ -18,9 +18,9 @@ export default {
   plugins: [
     // Allow bundling cjs modules (unlike webpack, rollup doesn't understand cjs)
     commonjs(),
-     // Allow node_modules resolution, so you can use 'external' to control
-     // which external modules to include in the bundle
-     // https://github.com/rollup/rollup-plugin-node-resolve#usage
+    // Allow node_modules resolution, so you can use 'external' to control
+    // which external modules to include in the bundle
+    // https://github.com/rollup/rollup-plugin-node-resolve#usage
     resolve(),
 
     // Resolve source maps to the original source


### PR DESCRIPTION
I think this is a good improvement and I couldn't see any other usage of `lodash` inside the library-starter. Now that lodash methods are served as *individial npm packages*, I feel it's good practice to take benefit of this! 😉 

---

*PS: please, squash and merge this (if accepted), I had to do it from GitHub since there is no CONTRIBUTING.md file and couldn't use my fork of the project in local to do the PR.*