### PR TITLE
fix(tools) fix docs publishing script

### DIFF
--- a/tools/gh-pages-publish.ts
+++ b/tools/gh-pages-publish.ts
@@ -14,7 +14,7 @@ if (typeof pkg.repository === "object") {
 }
 
 let parsedUrl = url.parse(repoUrl)
-let repository = parsedUrl.host || "" + parsedUrl.path || ""
+let repository = (parsedUrl.host || "") + (parsedUrl.path || "")
 let ghToken = process.env.GH_TOKEN
 
 echo("Deploying docs!!!")


### PR DESCRIPTION
Fix a mistake in operators precedence causing the docs publishing script to fail parsing the repo URL.