### PR TITLE
add mandatory lint before commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test:prod": "npm run lint && npm run test -- --coverage --no-cache",
     "deploy-docs": "ts-node tools/gh-pages-publish",
     "report-coverage": "cat ./coverage/lcov.info | coveralls",
-    "commit": "git-cz",
+    "commit": "npm run lint && git-cz",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post",
     "semantic-release-prepare": "ts-node tools/semantic-release-prepare",
     "precommit": "lint-staged",


### PR DESCRIPTION
(suggestion) most of times I have to perform two commits. First one has to do about my feat or fix, then I have to commit again to pass lint rules XD