### PR TITLE
fix the incorrect cli command

### DIFF
--- a/tools/semantic-release-prepare.ts
+++ b/tools/semantic-release-prepare.ts
@@ -25,7 +25,7 @@ console.log()
 if (pkg.repository.url.trim()) {
   console.log(colors.cyan("Now run:"))
   console.log(colors.cyan("  npm install -g semantic-release-cli"))
-  console.log(colors.cyan("  semantic-release setup"))
+  console.log(colors.cyan("  semantic-release-cli setup"))
   console.log()
   console.log(
     colors.cyan('Important! Answer NO to "Generate travis.yml" question')
@@ -44,7 +44,7 @@ if (pkg.repository.url.trim()) {
   )
   console.log(colors.cyan("Then run:"))
   console.log(colors.cyan("  npm install -g semantic-release-cli"))
-  console.log(colors.cyan("  semantic-release setup"))
+  console.log(colors.cyan("  semantic-release-cli setup"))
   console.log()
   console.log(
     colors.cyan('Important! Answer NO to "Generate travis.yml" question')


### PR DESCRIPTION
`semantic-release setup` will not work:

```
$ semantic-release setup

  Usage: semantic-release [options]

  Run automated package publishing


  Options:

    -b, --branch <branch>                Branch to release from
    -r, --repositoryUrl <repositoryUrl>  Git repository URL
    --verify-conditions <paths>          Comma separated list of paths or packages name for the verifyConditions plugin(s)
    --get-last-release <path>            Path or package name for the getLastRelease plugin
    --analyze-commits <path>             Path or package name for the analyzeCommits plugin
    --verify-release <paths>             Comma separated list of paths or packages name for the verifyRelease plugin(s)
    --generate-notes <path>              Path or package name for the generateNotes plugin
    --publish <paths>                    Comma separated list of paths or packages name for the publish plugin(s)
    --debug                              Output debugging information
    -d, --dry-run                        Dry-run mode, skipping verifyConditions, publishing and release, printing next version and release notes
    -h, --help                           output usage information

```

`semantic-release-cli setup` works:

```
$ semantic-release-cli setup
? What is your npm registry? 
```