### PR TITLE
Add .rpt2_cache to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ coverage
 dist
 compiled
 .awcache
+.rpt2_cache


### PR DESCRIPTION
The rollup-typescript-2 plugin outputs cache files to the rpt2_cache folder and these should be ignored so they don't show as tracked files/changes in git.

Closes #173 