### PR TITLE
feat: ignore docs folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dist
 compiled
 .awcache
 .rpt2_cache
+docs


### PR DESCRIPTION
Versioning docs folder is causing changes on every build and commit. `docs` should not be in version control since it is always rebuilt in the CI and deployed in its own branch. 

#185