### PR TITLE
Jest testEnvironment

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "transform": {
       ".(ts|tsx)": "<rootDir>/node_modules/ts-jest/preprocessor.js"
     },
+    "testEnvironment": "node",
     "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
     "moduleFileExtensions": [
       "ts",


### PR DESCRIPTION
The testEnvironment is an important parameter to specify whether globals like `window` are available in the tests. By having it unset, it was defaulting to `browser` which would cause problems with node.js projects.

Alternately, we could keep the defaults as browser to keep the current default target.