### PR TITLE
Move coverage option from package.json to npm scripts with --coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,9 +23,9 @@
     "prebuild": "rimraf dist",
     "build": "tsc --module commonjs && rollup -c rollup.config.ts && typedoc --out docs --target es6 --theme minimal --mode file src",
     "start": "rollup -c rollup.config.ts -w",
-    "test": "jest",
-    "test:watch": "jest --watch",
-    "test:prod": "npm run lint && npm run test -- --coverage --no-cache",
+    "test": "jest --coverage",
+    "test:watch": "jest --coverage --watch",
+    "test:prod": "npm run lint && npm run test -- --no-cache",
     "deploy-docs": "ts-node tools/gh-pages-publish",
     "report-coverage": "cat ./coverage/lcov.info | coveralls",
     "commit": "git-cz",
@@ -68,7 +68,6 @@
         "statements": 95
       }
     },
-    "collectCoverage": true,
     "collectCoverageFrom": [
       "src/*.{js,ts}"
     ]


### PR DESCRIPTION
As code coverage seems to break sourcemaps line numbers, this change moves the coverage option from package.json Jest config to npm script --coverage flag for IDE debugging to work as expected.

Close #171