### PR TITLE
Explicitly depend on shelljs.

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,13 +108,14 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "rollup-plugin-typescript2": "^0.18.0",
     "semantic-release": "^15.9.16",
+    "shelljs": "^0.8.3",
+    "travis-deploy-once": "^5.0.9",
     "ts-jest": "^23.10.2",
     "ts-node": "^7.0.1",
     "tslint": "^5.11.0",
     "tslint-config-prettier": "^1.15.0",
     "tslint-config-standard": "^8.0.1",
     "typedoc": "^0.12.0",
-    "typescript": "^3.0.3",
-    "travis-deploy-once": "^5.0.9"
+    "typescript": "^3.0.3"
   }
 }


### PR DESCRIPTION
Since `tools/init` uses shelljs directly, we should depend on it directly. Without this the `node_modules` layout set up by pnpm does not work.