### PR TITLE
Fix husky path in semantic-release-prepare script

### DIFF
--- a/tools/semantic-release-prepare.ts
+++ b/tools/semantic-release-prepare.ts
@@ -16,7 +16,7 @@ writeFileSync(
 )
 
 // Call husky to set up the hooks
-fork(path.resolve(__dirname, "..", "node_modules", "husky", "bin", "install"))
+fork(path.resolve(__dirname, "..", "node_modules", "husky", "lib", "installer", 'bin'), ['install'])
 
 console.log()
 console.log(colors.green("Done!!"))


### PR DESCRIPTION
As of Husky 1.x, the node_modules directory structure changed somewhat. The semantic-release-prepare script did not take this into account and, as a result of this, could not run to completion. 

Addresses #251 