### PR TITLE
Updates packages to latest versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,10 +101,10 @@
     "prompt": "^1.0.0",
     "replace-in-file": "^3.4.2",
     "rimraf": "^2.6.2",
-    "rollup": "^0.67.0",
+    "rollup": "^0.68.0",
     "rollup-plugin-commonjs": "^9.1.8",
     "rollup-plugin-json": "^3.1.0",
-    "rollup-plugin-node-resolve": "^3.4.0",
+    "rollup-plugin-node-resolve": "^4.0.0",
     "rollup-plugin-sourcemaps": "^0.4.2",
     "rollup-plugin-typescript2": "^0.18.0",
     "semantic-release": "^15.9.16",
@@ -113,7 +113,7 @@
     "tslint": "^5.11.0",
     "tslint-config-prettier": "^1.15.0",
     "tslint-config-standard": "^8.0.1",
-    "typedoc": "^0.12.0",
+    "typedoc": "^0.13.0",
     "typescript": "^3.0.3",
     "travis-deploy-once": "^5.0.9"
   }


### PR DESCRIPTION
rollup: 0.67.4 to 0.68.0
rollup-plugin-node-resolve: 3.4.0 to 4.0.0
typedoc: 0.12.0 to 0.13.0