### PR TITLE
style: run prettier on all files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,8 +7,8 @@ These steps will guide you through contributing to this project:
 - Fork the repo
 - Clone it and install dependencies
 
-		git clone https://github.com/YOUR-USERNAME/typescript-library-starter
-		npm install
+      		git clone https://github.com/YOUR-USERNAME/typescript-library-starter
+      		npm install
 
 Keep in mind that after running `npm install` the git repo is reset. So a good way to cope with this is to have a copy of the folder to push the changes, and the other to try them.
 

--- a/README.md
+++ b/README.md
@@ -25,14 +25,14 @@ npm install
 
 ### Features
 
- - Zero-setup. After running `npm install` things will setup for you :wink:
- - **[RollupJS](https://rollupjs.org/)** for multiple optimized bundles following the [standard convention](http://2ality.com/2017/04/setting-up-multi-platform-packages.html) and [Tree-shaking](https://alexjoverm.github.io/2017/03/06/Tree-shaking-with-Webpack-2-TypeScript-and-Babel/)
- - Tests, coverage and interactive watch mode using **[Jest](http://facebook.github.io/jest/)**
- - **[Prettier](https://github.com/prettier/prettier)** and **[TSLint](https://palantir.github.io/tslint/)** for code formatting and consistency
- - **Docs automatic generation and deployment** to `gh-pages`, using **[TypeDoc](http://typedoc.org/)**
- - Automatic types `(*.d.ts)` file generation
- - **[Travis](https://travis-ci.org)** integration and **[Coveralls](https://coveralls.io/)** report
- - (Optional) **Automatic releases and changelog**, using [Semantic release](https://github.com/semantic-release/semantic-release), [Commitizen](https://github.com/commitizen/cz-cli), [Conventional changelog](https://github.com/conventional-changelog/conventional-changelog) and [Husky](https://github.com/typicode/husky) (for the git hooks)
+- Zero-setup. After running `npm install` things will setup for you :wink:
+- **[RollupJS](https://rollupjs.org/)** for multiple optimized bundles following the [standard convention](http://2ality.com/2017/04/setting-up-multi-platform-packages.html) and [Tree-shaking](https://alexjoverm.github.io/2017/03/06/Tree-shaking-with-Webpack-2-TypeScript-and-Babel/)
+- Tests, coverage and interactive watch mode using **[Jest](http://facebook.github.io/jest/)**
+- **[Prettier](https://github.com/prettier/prettier)** and **[TSLint](https://palantir.github.io/tslint/)** for code formatting and consistency
+- **Docs automatic generation and deployment** to `gh-pages`, using **[TypeDoc](http://typedoc.org/)**
+- Automatic types `(*.d.ts)` file generation
+- **[Travis](https://travis-ci.org)** integration and **[Coveralls](https://coveralls.io/)** report
+- (Optional) **Automatic releases and changelog**, using [Semantic release](https://github.com/semantic-release/semantic-release), [Commitizen](https://github.com/commitizen/cz-cli), [Conventional changelog](https://github.com/conventional-changelog/conventional-changelog) and [Husky](https://github.com/typicode/husky) (for the git hooks)
 
 ### Importing library
 
@@ -50,13 +50,13 @@ import something from 'mylib/dist/lib/something'
 
 ### NPM scripts
 
- - `npm t`: Run test suite
- - `npm start`: Run `npm run build` in watch mode
- - `npm run test:watch`: Run test suite in [interactive watch mode](http://facebook.github.io/jest/docs/cli.html#watch)
- - `npm run test:prod`: Run linting and generate coverage
- - `npm run build`: Generate bundles and typings, create docs
- - `npm run lint`: Lints code
- - `npm run commit`: Commit using conventional commit style ([husky](https://github.com/typicode/husky) will tell you to use it if you haven't :wink:)
+- `npm t`: Run test suite
+- `npm start`: Run `npm run build` in watch mode
+- `npm run test:watch`: Run test suite in [interactive watch mode](http://facebook.github.io/jest/docs/cli.html#watch)
+- `npm run test:prod`: Run linting and generate coverage
+- `npm run build`: Generate bundles and typings, create docs
+- `npm run lint`: Lints code
+- `npm run commit`: Commit using conventional commit style ([husky](https://github.com/typicode/husky) will tell you to use it if you haven't :wink:)
 
 ### Excluding peerDependencies
 
@@ -67,9 +67,10 @@ Good news: the setup is here for you, you must only include the dependency name 
 ### Automatic releases
 
 _**Prerequisites**: you need to create/login accounts and add your project to:_
- - [npm](https://www.npmjs.com/)
- - [Travis CI](https://travis-ci.org)
- - [Coveralls](https://coveralls.io)
+
+- [npm](https://www.npmjs.com/)
+- [Travis CI](https://travis-ci.org)
+- [Coveralls](https://coveralls.io)
 
 _**Prerequisite for Windows**: Semantic-release uses
 **[node-gyp](https://github.com/nodejs/node-gyp)** so you will need to
@@ -102,8 +103,9 @@ Automatic releases are possible thanks to [semantic release](https://github.com/
 There is already set a `precommit` hook for formatting your code with Prettier :nail_care:
 
 By default, there are two disabled git hooks. They're set up when you run the `npm run semantic-release-prepare` script. They make sure:
- - You follow a [conventional commit message](https://github.com/conventional-changelog/conventional-changelog)
- - Your build is not going to fail in [Travis](https://travis-ci.org) (or your CI server), since it's runned locally before `git push`
+
+- You follow a [conventional commit message](https://github.com/conventional-changelog/conventional-changelog)
+- Your build is not going to fail in [Travis](https://travis-ci.org) (or your CI server), since it's runned locally before `git push`
 
 This makes more sense in combination with [automatic releases](#automatic-releases)
 
@@ -125,15 +127,17 @@ import "core-js/fn/promise"
 #### What is `npm install` doing on first run?
 
 It runs the script `tools/init` which sets up everything for you. In short, it:
- - Configures RollupJS for the build, which creates the bundles
- - Configures `package.json` (typings file, main file, etc)
- - Renames main src and test files
+
+- Configures RollupJS for the build, which creates the bundles
+- Configures `package.json` (typings file, main file, etc)
+- Renames main src and test files
 
 #### What if I don't want git-hooks, automatic releases or semantic-release?
 
 Then you may want to:
- - Remove `commitmsg`, `postinstall` scripts from `package.json`. That will not use those git hooks to make sure you make a conventional commit
- - Remove `npm run semantic-release` from `.travis.yml`
+
+- Remove `commitmsg`, `postinstall` scripts from `package.json`. That will not use those git hooks to make sure you make a conventional commit
+- Remove `npm run semantic-release` from `.travis.yml`
 
 #### What if I don't want to use coveralls or report my coverage?
 
@@ -164,6 +168,7 @@ Made with :heart: by [@alexjoverm](https://twitter.com/alexjoverm) and all these
 | [<img src="https://avatars1.githubusercontent.com/u/618922?v=3" width="100px;"/><br /><sub><b>Steve Lee</b></sub>](http;//opendirective.com)<br />[🔧](#tool-SteveALee "Tools") | [<img src="https://avatars0.githubusercontent.com/u/5127501?v=3" width="100px;"/><br /><sub><b>Flavio Corpa</b></sub>](http://flaviocorpa.com)<br />[💻](https://github.com/alexjoverm/typescript-library-starter/commits?author=kutyel "Code") | [<img src="https://avatars2.githubusercontent.com/u/22561997?v=3" width="100px;"/><br /><sub><b>Dom</b></sub>](https://github.com/foreggs)<br />[🔧](#tool-foreggs "Tools") | [<img src="https://avatars1.githubusercontent.com/u/755?v=4" width="100px;"/><br /><sub><b>Alex Coles</b></sub>](http://alexbcoles.com)<br />[📖](https://github.com/alexjoverm/typescript-library-starter/commits?author=myabc "Documentation") | [<img src="https://avatars2.githubusercontent.com/u/1093738?v=4" width="100px;"/><br /><sub><b>David Khourshid</b></sub>](https://github.com/davidkpiano)<br />[🔧](#tool-davidkpiano "Tools") | [<img src="https://avatars0.githubusercontent.com/u/7225802?v=4" width="100px;"/><br /><sub><b>Aarón García Hervás</b></sub>](https://aarongarciah.com)<br />[📖](https://github.com/alexjoverm/typescript-library-starter/commits?author=aarongarciah "Documentation") | [<img src="https://avatars2.githubusercontent.com/u/13683986?v=4" width="100px;"/><br /><sub><b>Jonathan Hart</b></sub>](https://www.stuajnht.co.uk)<br />[💻](https://github.com/alexjoverm/typescript-library-starter/commits?author=stuajnht "Code") |
 | [<img src="https://avatars0.githubusercontent.com/u/13509204?v=4" width="100px;"/><br /><sub><b>Sanjiv Lobo</b></sub>](https://github.com/Xndr7)<br />[📖](https://github.com/alexjoverm/typescript-library-starter/commits?author=Xndr7 "Documentation") | [<img src="https://avatars3.githubusercontent.com/u/7473800?v=4" width="100px;"/><br /><sub><b>Stefan Aleksovski</b></sub>](https://github.com/sAleksovski)<br />[💻](https://github.com/alexjoverm/typescript-library-starter/commits?author=sAleksovski "Code") | [<img src="https://avatars2.githubusercontent.com/u/8853426?v=4" width="100px;"/><br /><sub><b>dev.peerapong</b></sub>](https://github.com/devpeerapong)<br />[💻](https://github.com/alexjoverm/typescript-library-starter/commits?author=devpeerapong "Code") | [<img src="https://avatars0.githubusercontent.com/u/22260722?v=4" width="100px;"/><br /><sub><b>Aaron Groome</b></sub>](http://twitter.com/Racing5372)<br />[📖](https://github.com/alexjoverm/typescript-library-starter/commits?author=Racing5372 "Documentation") | [<img src="https://avatars3.githubusercontent.com/u/180963?v=4" width="100px;"/><br /><sub><b>Aaron Reisman</b></sub>](https://github.com/lifeiscontent)<br />[💻](https://github.com/alexjoverm/typescript-library-starter/commits?author=lifeiscontent "Code") | [<img src="https://avatars1.githubusercontent.com/u/32557482?v=4" width="100px;"/><br /><sub><b>kid-sk</b></sub>](https://github.com/kid-sk)<br />[📖](https://github.com/alexjoverm/typescript-library-starter/commits?author=kid-sk "Documentation") | [<img src="https://avatars0.githubusercontent.com/u/1503089?v=4" width="100px;"/><br /><sub><b>Andrea Gottardi</b></sub>](http://about.me/andreagot)<br />[📖](https://github.com/alexjoverm/typescript-library-starter/commits?author=AndreaGot "Documentation") |
 | [<img src="https://avatars3.githubusercontent.com/u/1375860?v=4" width="100px;"/><br /><sub><b>Yogendra Sharma</b></sub>](http://TechiesEyes.com)<br />[📖](https://github.com/alexjoverm/typescript-library-starter/commits?author=Yogendra0Sharma "Documentation") | [<img src="https://avatars3.githubusercontent.com/u/7407177?v=4" width="100px;"/><br /><sub><b>Rayan Salhab</b></sub>](http://linkedin.com/in/rayan-salhab/)<br />[💻](https://github.com/alexjoverm/typescript-library-starter/commits?author=cyphercodes "Code") |
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors](https://github.com/kentcdodds/all-contributors) specification. Contributions of any kind are welcome!

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -14,21 +14,21 @@ orientation.
 Examples of behavior that contributes to creating a positive environment
 include:
 
-* Using welcoming and inclusive language
-* Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
-* Showing empathy towards other community members
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
 
 Examples of unacceptable behavior by participants include:
 
-* The use of sexualized language or imagery and unwelcome sexual attention or
-advances
-* Trolling, insulting/derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or electronic
+- The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic
   address, without explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
+- Other conduct which could reasonably be considered inappropriate in a
   professional setting
 
 ## Our Responsibilities

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -13,12 +13,12 @@ export default {
   input: `src/${libraryName}.ts`,
   output: [
     { file: pkg.main, name: camelCase(libraryName), format: 'umd', sourcemap: true },
-    { file: pkg.module, format: 'es', sourcemap: true },
+    { file: pkg.module, format: 'es', sourcemap: true }
   ],
   // Indicate here external modules you don't wanna include in your bundle (i.e.: 'lodash')
   external: [],
   watch: {
-    include: 'src/**',
+    include: 'src/**'
   },
   plugins: [
     // Allow json resolution
@@ -33,6 +33,6 @@ export default {
     resolve(),
 
     // Resolve source maps to the original source
-    sourceMaps(),
-  ],
+    sourceMaps()
+  ]
 }

--- a/src/library.ts
+++ b/src/library.ts
@@ -1,6 +1,4 @@
 // Import here Polyfills if needed. Recommended core-js (npm i -D core-js)
-  // import "core-js/fn/array.find"
-  // ...
-export default class DummyClass {
-
-}
+// import "core-js/fn/array.find"
+// ...
+export default class DummyClass {}

--- a/test/library.test.ts
+++ b/test/library.test.ts
@@ -1,14 +1,14 @@
-import DummyClass from "../src/--libraryname--"
+import DummyClass from '../src/--libraryname--'
 
 /**
  * Dummy test
  */
-describe("Dummy test", () => {
-  it("works if true is truthy", () => {
+describe('Dummy test', () => {
+  it('works if true is truthy', () => {
     expect(true).toBeTruthy()
   })
 
-  it("DummyClass is instantiable", () => {
+  it('DummyClass is instantiable', () => {
     expect(new DummyClass()).toBeInstanceOf(DummyClass)
   })
 })

--- a/tools/gh-pages-publish.ts
+++ b/tools/gh-pages-publish.ts
@@ -1,12 +1,12 @@
-const { cd, exec, echo, touch } = require("shelljs")
-const { readFileSync } = require("fs")
-const url = require("url")
+const { cd, exec, echo, touch } = require('shelljs')
+const { readFileSync } = require('fs')
+const url = require('url')
 
 let repoUrl
-let pkg = JSON.parse(readFileSync("package.json") as any)
-if (typeof pkg.repository === "object") {
-  if (!pkg.repository.hasOwnProperty("url")) {
-    throw new Error("URL does not exist in repository section")
+let pkg = JSON.parse(readFileSync('package.json') as any)
+if (typeof pkg.repository === 'object') {
+  if (!pkg.repository.hasOwnProperty('url')) {
+    throw new Error('URL does not exist in repository section')
   }
   repoUrl = pkg.repository.url
 } else {
@@ -14,18 +14,16 @@ if (typeof pkg.repository === "object") {
 }
 
 let parsedUrl = url.parse(repoUrl)
-let repository = (parsedUrl.host || "") + (parsedUrl.path || "")
+let repository = (parsedUrl.host || '') + (parsedUrl.path || '')
 let ghToken = process.env.GH_TOKEN
 
-echo("Deploying docs!!!")
-cd("docs")
-touch(".nojekyll")
-exec("git init")
-exec("git add .")
+echo('Deploying docs!!!')
+cd('docs')
+touch('.nojekyll')
+exec('git init')
+exec('git add .')
 exec('git config user.name "--username--"')
 exec('git config user.email "--usermail--"')
 exec('git commit -m "docs(docs): update gh-pages"')
-exec(
-  `git push --force --quiet "https://${ghToken}@${repository}" master:gh-pages`
-)
-echo("Docs deployed!!")
+exec(`git push --force --quiet "https://${ghToken}@${repository}" master:gh-pages`)
+echo('Docs deployed!!')

--- a/tools/init.ts
+++ b/tools/init.ts
@@ -1,46 +1,37 @@
 /**
  * This script runs automatically after your first npm-install.
  */
-const _prompt = require("prompt")
-const { mv, rm, which, exec } = require("shelljs")
-const replace = require("replace-in-file")
-const colors = require("colors")
-const path = require("path")
-const { readFileSync, writeFileSync } = require("fs")
-const { fork } = require("child_process")
+const _prompt = require('prompt')
+const { mv, rm, which, exec } = require('shelljs')
+const replace = require('replace-in-file')
+const colors = require('colors')
+const path = require('path')
+const { readFileSync, writeFileSync } = require('fs')
+const { fork } = require('child_process')
 
 // Note: These should all be relative to the project root directory
-const rmDirs = [
-  ".git"
-]
-const rmFiles = [
-  ".all-contributorsrc",
-  ".gitattributes",
-  "tools/init.ts"
-]
+const rmDirs = ['.git']
+const rmFiles = ['.all-contributorsrc', '.gitattributes', 'tools/init.ts']
 const modifyFiles = [
-  "LICENSE",
-  "package.json",
-  "rollup.config.ts",
-  "test/library.test.ts",
-  "tools/gh-pages-publish.ts"
+  'LICENSE',
+  'package.json',
+  'rollup.config.ts',
+  'test/library.test.ts',
+  'tools/gh-pages-publish.ts'
 ]
 const renameFiles = [
-  ["src/library.ts", "src/--libraryname--.ts"],
-  ["test/library.test.ts", "test/--libraryname--.test.ts"]
+  ['src/library.ts', 'src/--libraryname--.ts'],
+  ['test/library.test.ts', 'test/--libraryname--.test.ts']
 ]
 
 const _promptSchemaLibraryName = {
   properties: {
     library: {
-      description: colors.cyan(
-        "What do you want the library to be called? (use kebab-case)"
-      ),
+      description: colors.cyan('What do you want the library to be called? (use kebab-case)'),
       pattern: /^[a-z]+(\-[a-z]+)*$/,
-      type: "string",
+      type: 'string',
       required: true,
-      message:
-        '"kebab-case" uses lowercase letters, and hyphens for any punctuation'
+      message: '"kebab-case" uses lowercase letters, and hyphens for any punctuation'
     }
   }
 }
@@ -49,12 +40,10 @@ const _promptSchemaLibrarySuggest = {
   properties: {
     useSuggestedName: {
       description: colors.cyan(
-        'Would you like it to be called "' +
-          libraryNameSuggested() +
-          '"? [Yes/No]'
+        'Would you like it to be called "' + libraryNameSuggested() + '"? [Yes/No]'
       ),
       pattern: /^(y(es)?|n(o)?)$/i,
-      type: "string",
+      type: 'string',
       required: true,
       message: 'You need to type "Yes" or "No" to continue...'
     }
@@ -62,21 +51,19 @@ const _promptSchemaLibrarySuggest = {
 }
 
 _prompt.start()
-_prompt.message = ""
+_prompt.message = ''
 
 // Clear console
-process.stdout.write('\x1B[2J\x1B[0f');
+process.stdout.write('\x1B[2J\x1B[0f')
 
-if (!which("git")) {
-  console.log(colors.red("Sorry, this script requires git"))
+if (!which('git')) {
+  console.log(colors.red('Sorry, this script requires git'))
   removeItems()
   process.exit(1)
 }
 
 // Say hi!
-console.log(
-  colors.cyan("Hi! You're almost ready to make the next great TypeScript library.")
-)
+console.log(colors.cyan("Hi! You're almost ready to make the next great TypeScript library."))
 
 // Generate the library name and start the tasks
 if (process.env.CI == null) {
@@ -90,8 +77,6 @@ if (process.env.CI == null) {
   setupLibrary(libraryNameSuggested())
 }
 
-
-
 /**
  * Asks the user for the name of the library if it has been cloned into the
  * default directory, or if they want a different name to the one suggested
@@ -99,7 +84,7 @@ if (process.env.CI == null) {
 function libraryNameCreate() {
   _prompt.get(_promptSchemaLibraryName, (err: any, res: any) => {
     if (err) {
-      console.log(colors.red("Sorry, there was an error building the workspace :("))
+      console.log(colors.red('Sorry, there was an error building the workspace :('))
       removeItems()
       process.exit(1)
       return
@@ -120,7 +105,7 @@ function libraryNameSuggestedAccept() {
       libraryNameCreate()
     }
 
-    if (res.useSuggestedName.toLowerCase().charAt(0) === "y") {
+    if (res.useSuggestedName.toLowerCase().charAt(0) === 'y') {
       setupLibrary(libraryNameSuggested())
     } else {
       libraryNameCreate()
@@ -131,7 +116,7 @@ function libraryNameSuggestedAccept() {
 /**
  * The library name is suggested by looking at the directory name of the
  * tools parent directory and converting it to kebab-case
- * 
+ *
  * The regex for this looks for any non-word or non-digit character, or
  * an underscore (as it's a word character), and replaces it with a dash.
  * Any leading or trailing dashes are then removed, before the string is
@@ -139,9 +124,9 @@ function libraryNameSuggestedAccept() {
  */
 function libraryNameSuggested() {
   return path
-    .basename(path.resolve(__dirname, ".."))
-    .replace(/[^\w\d]|_/g, "-")
-    .replace(/^-+|-+$/g, "")
+    .basename(path.resolve(__dirname, '..'))
+    .replace(/[^\w\d]|_/g, '-')
+    .replace(/^-+|-+$/g, '')
     .toLowerCase()
 }
 
@@ -149,30 +134,26 @@ function libraryNameSuggested() {
  * Checks if the suggested library name is the default, which is 'typescript-library-starter'
  */
 function libraryNameSuggestedIsDefault() {
-  if (libraryNameSuggested() === "typescript-library-starter") {
+  if (libraryNameSuggested() === 'typescript-library-starter') {
     return true
   }
 
   return false
 }
 
-
-
 /**
  * Calls all of the functions needed to setup the library
- * 
+ *
  * @param libraryName
  */
 function setupLibrary(libraryName: string) {
   console.log(
-    colors.cyan(
-      "\nThanks for the info. The last few changes are being made... hang tight!\n\n"
-    )
+    colors.cyan('\nThanks for the info. The last few changes are being made... hang tight!\n\n')
   )
 
   // Get the Git username and email before the .git directory is removed
-  let username = exec("git config user.name").stdout.trim()
-  let usermail = exec("git config user.email").stdout.trim()
+  let username = exec('git config user.name').stdout.trim()
+  let usermail = exec('git config user.email').stdout.trim()
 
   removeItems()
 
@@ -189,92 +170,86 @@ function setupLibrary(libraryName: string) {
  * Removes items from the project that aren't needed after the initial setup
  */
 function removeItems() {
-  console.log(colors.underline.white("Removed"))
+  console.log(colors.underline.white('Removed'))
 
   // The directories and files are combined here, to simplify the function,
   // as the 'rm' command checks the item type before attempting to remove it
   let rmItems = rmDirs.concat(rmFiles)
-  rm("-rf", rmItems.map(f => path.resolve(__dirname, "..", f)))
-  console.log(colors.red(rmItems.join("\n")))
+  rm('-rf', rmItems.map(f => path.resolve(__dirname, '..', f)))
+  console.log(colors.red(rmItems.join('\n')))
 
-  console.log("\n")
+  console.log('\n')
 }
 
 /**
  * Updates the contents of the template files with the library name or user details
- * 
- * @param libraryName 
- * @param username 
- * @param usermail 
+ *
+ * @param libraryName
+ * @param username
+ * @param usermail
  */
 function modifyContents(libraryName: string, username: string, usermail: string) {
-  console.log(colors.underline.white("Modified"))
+  console.log(colors.underline.white('Modified'))
 
-  let files = modifyFiles.map(f => path.resolve(__dirname, "..", f))
+  let files = modifyFiles.map(f => path.resolve(__dirname, '..', f))
   try {
     const changes = replace.sync({
       files,
       from: [/--libraryname--/g, /--username--/g, /--usermail--/g],
       to: [libraryName, username, usermail]
     })
-    console.log(colors.yellow(modifyFiles.join("\n")))
+    console.log(colors.yellow(modifyFiles.join('\n')))
   } catch (error) {
-    console.error("An error occurred modifying the file: ", error)
+    console.error('An error occurred modifying the file: ', error)
   }
 
-  console.log("\n")
+  console.log('\n')
 }
 
 /**
  * Renames any template files to the new library name
- * 
- * @param libraryName 
+ *
+ * @param libraryName
  */
 function renameItems(libraryName: string) {
-  console.log(colors.underline.white("Renamed"))
+  console.log(colors.underline.white('Renamed'))
 
   renameFiles.forEach(function(files) {
     // Files[0] is the current filename
     // Files[1] is the new name
     let newFilename = files[1].replace(/--libraryname--/g, libraryName)
-    mv(
-      path.resolve(__dirname, "..", files[0]),
-      path.resolve(__dirname, "..", newFilename)
-    )
-    console.log(colors.cyan(files[0] + " => " + newFilename))
+    mv(path.resolve(__dirname, '..', files[0]), path.resolve(__dirname, '..', newFilename))
+    console.log(colors.cyan(files[0] + ' => ' + newFilename))
   })
 
-  console.log("\n")
+  console.log('\n')
 }
 
 /**
  * Calls any external programs to finish setting up the library
  */
 function finalize() {
-  console.log(colors.underline.white("Finalizing"))
+  console.log(colors.underline.white('Finalizing'))
 
   // Recreate Git folder
-  let gitInitOutput = exec('git init "' + path.resolve(__dirname, "..") + '"', {
+  let gitInitOutput = exec('git init "' + path.resolve(__dirname, '..') + '"', {
     silent: true
   }).stdout
-  console.log(colors.green(gitInitOutput.replace(/(\n|\r)+/g, "")))
+  console.log(colors.green(gitInitOutput.replace(/(\n|\r)+/g, '')))
 
   // Remove post-install command
-  let jsonPackage = path.resolve(__dirname, "..", "package.json")
+  let jsonPackage = path.resolve(__dirname, '..', 'package.json')
   const pkg = JSON.parse(readFileSync(jsonPackage) as any)
 
   // Note: Add items to remove from the package file here
   delete pkg.scripts.postinstall
 
   writeFileSync(jsonPackage, JSON.stringify(pkg, null, 2))
-  console.log(colors.green("Postinstall script has been removed"))
+  console.log(colors.green('Postinstall script has been removed'))
 
   // Initialize Husky
-  fork(
-    path.resolve(__dirname, "..", "node_modules", "husky", "bin", "install"),
-    { silent: true }
-  );
-  console.log(colors.green("Git hooks set up"))
+  fork(path.resolve(__dirname, '..', 'node_modules', 'husky', 'bin', 'install'), { silent: true })
+  console.log(colors.green('Git hooks set up'))
 
-  console.log("\n")
+  console.log('\n')
 }

--- a/tools/semantic-release-prepare.ts
+++ b/tools/semantic-release-prepare.ts
@@ -1,54 +1,39 @@
-const path = require("path")
-const { fork } = require("child_process")
-const colors = require("colors")
+const path = require('path')
+const { fork } = require('child_process')
+const colors = require('colors')
 
-const { readFileSync, writeFileSync } = require("fs")
-const pkg = JSON.parse(
-  readFileSync(path.resolve(__dirname, "..", "package.json"))
-)
+const { readFileSync, writeFileSync } = require('fs')
+const pkg = JSON.parse(readFileSync(path.resolve(__dirname, '..', 'package.json')))
 
-pkg.scripts.prepush = "npm run test:prod && npm run build"
-pkg.scripts.commitmsg = "commitlint -E HUSKY_GIT_PARAMS"
+pkg.scripts.prepush = 'npm run test:prod && npm run build'
+pkg.scripts.commitmsg = 'commitlint -E HUSKY_GIT_PARAMS'
 
-writeFileSync(
-  path.resolve(__dirname, "..", "package.json"),
-  JSON.stringify(pkg, null, 2)
-)
+writeFileSync(path.resolve(__dirname, '..', 'package.json'), JSON.stringify(pkg, null, 2))
 
 // Call husky to set up the hooks
-fork(path.resolve(__dirname, "..", "node_modules", "husky", "lib", "installer", 'bin'), ['install'])
+fork(path.resolve(__dirname, '..', 'node_modules', 'husky', 'lib', 'installer', 'bin'), ['install'])
 
 console.log()
-console.log(colors.green("Done!!"))
+console.log(colors.green('Done!!'))
 console.log()
 
 if (pkg.repository.url.trim()) {
-  console.log(colors.cyan("Now run:"))
-  console.log(colors.cyan("  npm install -g semantic-release-cli"))
-  console.log(colors.cyan("  semantic-release-cli setup"))
+  console.log(colors.cyan('Now run:'))
+  console.log(colors.cyan('  npm install -g semantic-release-cli'))
+  console.log(colors.cyan('  semantic-release-cli setup'))
+  console.log()
+  console.log(colors.cyan('Important! Answer NO to "Generate travis.yml" question'))
   console.log()
   console.log(
-    colors.cyan('Important! Answer NO to "Generate travis.yml" question')
-  )
-  console.log()
-  console.log(
-    colors.gray(
-      'Note: Make sure "repository.url" in your package.json is correct before'
-    )
+    colors.gray('Note: Make sure "repository.url" in your package.json is correct before')
   )
 } else {
-  console.log(
-    colors.red(
-      'First you need to set the "repository.url" property in package.json'
-    )
-  )
-  console.log(colors.cyan("Then run:"))
-  console.log(colors.cyan("  npm install -g semantic-release-cli"))
-  console.log(colors.cyan("  semantic-release-cli setup"))
+  console.log(colors.red('First you need to set the "repository.url" property in package.json'))
+  console.log(colors.cyan('Then run:'))
+  console.log(colors.cyan('  npm install -g semantic-release-cli'))
+  console.log(colors.cyan('  semantic-release-cli setup'))
   console.log()
-  console.log(
-    colors.cyan('Important! Answer NO to "Generate travis.yml" question')
-  )
+  console.log(colors.cyan('Important! Answer NO to "Generate travis.yml" question'))
 }
 
 console.log()

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "moduleResolution": "node",
     "target": "es5",
-    "module":"es2015",
+    "module": "es2015",
     "lib": ["es2015", "es2016", "es2017", "dom"],
     "strict": true,
     "sourceMap": true,
@@ -12,11 +12,7 @@
     "emitDecoratorMetadata": true,
     "declarationDir": "dist/types",
     "outDir": "dist/lib",
-    "typeRoots": [
-      "node_modules/@types"
-    ]
+    "typeRoots": ["node_modules/@types"]
   },
-  "include": [
-    "src"
-  ]
+  "include": ["src"]
 }

--- a/tslint.json
+++ b/tslint.json
@@ -1,6 +1,3 @@
 {
-  "extends": [
-    "tslint-config-standard",
-    "tslint-config-prettier"
-  ]
+  "extends": ["tslint-config-standard", "tslint-config-prettier"]
 }


### PR DESCRIPTION
### issue
I've noticed that changing and committing files introduced format related changes.

### solution
format all files to conform to the prettier config defined in `package.json`.

### next steps
I think prettier rules should be checked into a `.prettierrc` file,
and should run on all files before the initial commit.

---

**to reproduce this commit**:
- `yarn install --ignore-scripts`
- `rm yarn.lock`
- `yarn prettier '**/**'`