### PR TITLE
fix: update typedoc and ts version to fix build error

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "tslint": "^5.11.0",
     "tslint-config-prettier": "^1.15.0",
     "tslint-config-standard": "^8.0.1",
-    "typedoc": "^0.12.0",
-    "typescript": "^3.0.3"
+    "typedoc": "^0.14.2",
+    "typescript": "^4.0.5"
   }
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/11473889/99529571-fed65200-29da-11eb-88ae-91f4cdd876c6.png)

when i use the code in master and run `npm run build`,  i will get the parse error as above. The reason for this problem is the version of `typedoc` is too low.  We can just change the `typedoc` and `typescript` in `package.json` and reinstall dependencies, it can work as well.

```
    "typedoc": "^0.14.2",
    "typescript": "^4.0.5"
```